### PR TITLE
dir_data.hFile type long=>intptr_t  (crash on win64)

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -94,7 +94,7 @@
 typedef struct dir_data {
         int  closed;
 #ifdef _WIN32
-        long hFile;
+        intptr_t hFile;
         char pattern[MAX_PATH+1];
 #else
         DIR *dir;


### PR DESCRIPTION
Hello!

There vere crash in lfs.dll due to long type for handle on win64 platform.
so i change long => intptr_t

thx
